### PR TITLE
Add commit size filter

### DIFF
--- a/frontend/src/components/c-ramp.vue
+++ b/frontend/src/components/c-ramp.vue
@@ -1,7 +1,7 @@
 <template lang="pug">
 .ramp
   template(v-if="tframe === 'commit'")
-    template(v-for="(slice, j) in user.commits")
+    template(v-for="(slice, j) in filteredCommits")
       template(v-for="(commit, k) in slice.commitResults")
         a.ramp__slice(
           draggable="false",
@@ -88,10 +88,20 @@ export default {
       rampSize: 0.01,
       mergeCommitRampSize: this.rampSize * 20,
       deletesContributionRampSize: this.rampSize * 20,
+      // Todo make use of typescript type safety to prevent misuse of filteredCommits.
+      filteredCommits: this.user.commits,
     };
+  },
+  watch: {
+    '$store.state.commitSizeThreshold': function () {
+      this.filterCommitsBySize(this.$store.state.commitSizeThreshold);
+    },
   },
 
   methods: {
+    filterCommitsBySize(size) {
+      this.filteredCommits = this.user.commits.filter((commit) => commit.insertions >= size);
+    },
     getLink(commit) {
       return window.getCommitLink(commit.repoId, commit.hash);
     },

--- a/frontend/src/store/store.ts
+++ b/frontend/src/store/store.ts
@@ -18,6 +18,7 @@ export default createStore<StoreState>({
     loadingOverlayCount: 0,
     loadingOverlayMessage: '',
     isTabActive: true,
+    commitSizeThreshold: 0,
   } as StoreState,
   mutations: {
     updateTabZoomInfo(state: StoreState, info: ZoomInfo) {
@@ -81,6 +82,9 @@ export default createStore<StoreState>({
         file.active = isActive;
         file.wasCodeLoaded = file.wasCodeLoaded || file.active;
       });
+    },
+    updateCommitSizeThreshold(state: StoreState, commitSizeThreshold: number) {
+      state.commitSizeThreshold = commitSizeThreshold;
     },
   },
   actions: {

--- a/frontend/src/styles/summary-chart.scss
+++ b/frontend/src/styles/summary-chart.scss
@@ -68,7 +68,8 @@
       vertical-align: middle;
     }
 
-    .search_box {
+    .search_box,
+    .commit_size_filter_box {
       align-items: center;
       display: flex;
     }

--- a/frontend/src/types/vuex.d.ts
+++ b/frontend/src/types/vuex.d.ts
@@ -48,6 +48,7 @@ interface StoreState {
   loadingOverlayCount: number;
   loadingOverlayMessage: string;
   isTabActive: boolean;
+  commitSizeThreshold: number;
 }
 
 declare module '@vue/runtime-core' {

--- a/frontend/src/views/c-summary.vue
+++ b/frontend/src/views/c-summary.vue
@@ -6,6 +6,10 @@
         input(type="text", v-on:change="updateFilterSearch", v-model="filterSearch")
         label search
         button.mui-btn.mui-btn--raised(type="button", v-on:click.prevent="resetFilterSearch") x
+      .mui-textfield.commit_size_filter_box
+        input(type="number", step="1", min="0", v-on:change="updateCommitSizeThreshold", v-model="commitSizeThreshold")
+        label minimum commit size
+        button.mui-btn.mui-btn--raised(type="button", v-on:click.prevent="resetCommitSizeThreshold") x
       .mui-select.grouping
         select(v-model="filterGroupSelection")
           option(value="groupByNone") None
@@ -180,6 +184,7 @@ export default defineComponent({
       fileTypes: [] as string[],
       filtered: [] as User[][],
       filterSearch: '',
+      commitSizeThreshold: 0,
       filterGroupSelection: FilterGroupSelection.GroupByRepos,
       sortGroupSelection: SortGroupSelection.GroupTitleDsc, // UI for sorting groups
       sortWithinGroupSelection: SortWithinGroupSelection.Title, // UI for sorting within groups
@@ -364,6 +369,17 @@ export default defineComponent({
       // Only called from an input onchange event, target guaranteed to be input element
       this.filterSearch = (evt.target as HTMLInputElement).value;
       this.getFiltered();
+    },
+
+    resetCommitSizeThreshold() {
+      this.commitSizeThreshold = 0;
+    },
+    updateCommitSizeThreshold(evt: Event) {
+      this.commitSizeThreshold = Math.floor((evt.target as HTMLInputElement).valueAsNumber);
+
+      if (Number.isNaN(this.commitSizeThreshold)) {
+        this.commitSizeThreshold = 0;
+      }
     },
 
     setSummaryHash() {

--- a/frontend/src/views/c-summary.vue
+++ b/frontend/src/views/c-summary.vue
@@ -184,7 +184,7 @@ export default defineComponent({
       fileTypes: [] as string[],
       filtered: [] as User[][],
       filterSearch: '',
-      commitSizeThreshold: 0,
+      commitSizeThreshold: 0 as number,
       filterGroupSelection: FilterGroupSelection.GroupByRepos,
       sortGroupSelection: SortGroupSelection.GroupTitleDsc, // UI for sorting groups
       sortWithinGroupSelection: SortWithinGroupSelection.Title, // UI for sorting within groups
@@ -373,6 +373,8 @@ export default defineComponent({
 
     resetCommitSizeThreshold() {
       this.commitSizeThreshold = 0;
+      this.$store.commit('updateCommitSizeThreshold', this.commitSizeThreshold);
+      this.getFiltered();
     },
     updateCommitSizeThreshold(evt: Event) {
       this.commitSizeThreshold = Math.floor((evt.target as HTMLInputElement).valueAsNumber);
@@ -380,6 +382,8 @@ export default defineComponent({
       if (Number.isNaN(this.commitSizeThreshold)) {
         this.commitSizeThreshold = 0;
       }
+      this.$store.commit('updateCommitSizeThreshold', this.commitSizeThreshold);
+      this.getFiltered();
     },
 
     setSummaryHash() {


### PR DESCRIPTION
<!--
    If this pull request fully addresses an issue, use:
    Fixes #xxxx

    If this pull request partially addresses an issue, use:
    Part of #xxxx

    If this pull request addresses multiple issues, put them in multiple lines:
    Fixes #xxxx
    Fixes #yyyy

    Format the title of the pull request with most relevant issue number as follows:
    [#xxxx] Title
-->

### Proposed commit message
<!--
    Propose a detailed commit message for this pull request within the triple backticks below.
    Wrap lines at 72 characters.

    Guide on how to write a good commit message:
    https://oss-generic.github.io/process/docs/FormatsAndConventions.html#commit-message
-->
```
Currently, the only way to judge size of commits would be either to look
at the area of each commit ramp for a rough idea of how big a commit
is, or by mousing over a specific commit to get a concrete value on the
size of the commit.

Commit size is a valuable piece of information for educators which aids
them when looking out for excessively large commits which may be a
sign of fluffing up contribution or simply bad committing habits.
Presently, commit size is either loose (rough idea from judging area of
commit ramp) or tedious to gather (mousing over commits that seem
to be large) especially when there is a high quantity of large commits
which is usually bunched up and difficult to analyse (in the case of bad
committing habits).
```

### Other information
<!--
    Are there other relevant information, such as special testing instructions,
    which will help the reviewer better understand the code?

    You may also include a brief description of why the problem occurred.
-->
**Note:** 
- Commit size in this case refers to the lines of codes inserted in the commit.
- Filtering by daily code insertions should also help find large bursts of daily code contribution. Hence, daily code contribution is used instead of singular commit sizes.

**Disclaimer:**
Code in this pull request is only a functioning prototype of the feature, meant to experiment on its usefulness to the target audience of RepoSense. Testing and documentation has not, and will not be done unless the feature is confirmed to be worthwhile to fully implement.

**Pros:**
- Easier for users to look out for commits that are excessively large.
   - Students can correct bad habit.
   - Educators can look out for foul play (boosting contribution with fluff commits).

**Cons:**
- Introduces more components to GUI.
   - Harder to maintain in the future.
   - Makes GUI harder to navigate for users.

**Explanation of feature added:**
- New text field for users to fill in (if needed).
- Field only takes in positive integer values (input is validated).
- X button resets value in the field to 0.
- Value in the box denotes the minimum commit size (inclusive) to show.
- Any group of commits (within the day) with a total size smaller than the value will be hidden.

**Screenshots:**
![image](https://github.com/jq1836/RepoSense/assets/95712150/ce08ffb1-18e0-4db8-a87b-e89e6f5d636f)
![image](https://github.com/jq1836/RepoSense/assets/95712150/1b47dddb-f48c-45e2-8a5a-1db2c4d61e37)
![image](https://github.com/jq1836/RepoSense/assets/95712150/497f8245-5ae2-4bf7-a1c0-5a1cbf6e0475)

**Known Issues:**
Commits panel will also be filtered, however, commits that are filtered out will still be visible in the bottom section of the commits panel.
![image](https://github.com/jq1836/RepoSense/assets/95712150/4c3b7dda-43a6-472e-87e4-a671e92d8177)

Commits panel is not responsive when selecting a different zoom region. Updating the minimum commit size will refresh the commits panel component.


